### PR TITLE
Improvement/Use default handlerStack

### DIFF
--- a/Service/TextMasterApi.php
+++ b/Service/TextMasterApi.php
@@ -212,8 +212,7 @@ class TextMasterApi
 
     private function createGuzzleClient(array $options): Client
     {
-        $stack = new HandlerStack();
-        $stack->setHandler(new CurlHandler());
+        $stack = HandlerStack::create();
         $stack->push(Middleware::mapRequest(function (RequestInterface $request) use ($options) {
             $date = new \DateTime('now', new \DateTimeZone('UTC'));
 


### PR DESCRIPTION
```
HandlerStack::create
```
fait dans l'ordre:
- `new self($handler ?: Utils::chooseHandler());` => Il utilise le meilleur handler disponible (actuellement on prend Curl)
- `$stack->push(Middleware::httpErrors(), 'http_errors');` => Il ajoute le middleWare qui throw une exception si 400
- `$stack->push(Middleware::redirect(), 'allow_redirects');` => "Middleware that handles request redirects."
- `$stack->push(Middleware::cookies(), 'cookies');` => "Middleware that adds cookies to requests."
- `$stack->push(Middleware::prepareBody(), 'prepare_body');` => "This middleware adds a default content-type if possible, a default content-length or transfer-encoding header, and the expect header."

En particulier celui qui nous intéresse est le httpErrors qui automatiquement renvoit une exception si le code est >=400 ou >= 500.

Ca éviterait la double gestion de https://github.com/weglot/core/pull/3477 qui
- a la fois try catch les guzzleException
- à la fois check le status code